### PR TITLE
Fix GenerateClientSecret

### DIFF
--- a/apple/secret.go
+++ b/apple/secret.go
@@ -40,7 +40,8 @@ func GenerateClientSecret(signingKey, teamID, clientID, keyID string) (string, e
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-	token.Header["key"] = keyID
+	token.Header["alg"] = "ES256"
+	token.Header["kid"] = keyID
 
 	return token.SignedString(privKey)
 }

--- a/apple/secret_test.go
+++ b/apple/secret_test.go
@@ -77,7 +77,7 @@ HAqVePERhISfN6cwZt5p8B3/JUwSR8el66DF7Jm57BM=
 				assert.True(t, b, "invalid subject")
 				assert.Equal(t, "com.example.app", r)
 
-				decoded.Algorithm()
+				assert.Equal(t, jwt.ES256, decoded.Algorithm())
 			}
 		})
 	}


### PR DESCRIPTION
There should be `alg` and `kid` in JWT header, see `Creating the Client Secret` in [Generate and Validate Tokens](https://developer.apple.com/documentation/sign_in_with_apple/generate_and_validate_tokens). Or we receive the error: `invalid_client`.

| Header | Description |
| -- | -- |
| alg | The algorithm used to sign the token. For Sign in with Apple, use ES256. |
| kid | A 10-character key identifier generated for the Sign in with Apple private key associated with your developer account. |