### PR TITLE
Migrate to github.com/golang-jwt/jwt

### DIFF
--- a/apple/secret.go
+++ b/apple/secret.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt"
 )
 
 /*


### PR DESCRIPTION
github.com/dgrijalva/jwt-go has moved to github.com/golang-jwt/jwt

Dgrijalva's version also has (had?) a security flaw

I have tested it on my current project and the change has no side effects.