### PR TITLE
Add ErrorDescription field to ValidationResponse

### DIFF
--- a/apple/model.go
+++ b/apple/model.go
@@ -65,6 +65,9 @@ type ValidationResponse struct {
 
 	// Used to capture any error returned by the endpoint. Do not trust the response if this error is not nil
 	Error string `json:"error"`
+	
+	// A more detailed precision about the current error.
+	ErrorDescription string `json:"error_description"`
 }
 
 // RefreshResponse is a subset of ValidationResponse returned by Apple


### PR DESCRIPTION
Hello, I noticed that the `ErrorDescription` field is missing like in the following [example](https://developer.apple.com/forums/thread/679497).

So I added it, here is how it looks with it:

```go
var resp apple.ValidationResponse
if err := o.Apple.VerifyAppToken(ctx, apple.AppValidationTokenRequest{
	ClientID:     o.appleClientID,
	ClientSecret: o.appleClientSecret,
	Code:         token,
}, &resp); err != nil {
	return nil, err
}

if resp.Error != "" {
	return nil, fmt.Errorf("%s: %s", resp.Error, resp.ErrorDescription)
}
```

Result:
```bash
error="invalid_grant: The code has expired or has been revoked."
```

Thank you 👍