### PR TITLE
v4 of golang-jwt is out

### DIFF
--- a/apple/secret.go
+++ b/apple/secret.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"time"
 
-	"github.com/golang-jwt/jwt"
+	"github.com/golang-jwt/jwt/v4"
 )
 
 /*


### PR DESCRIPTION
"Starting with v4.0.0 this project adds Go module support, but maintains backwards compatibility with older v3.x.y tags and upstream github.com/dgrijalva/jwt-go. See the MIGRATION_GUIDE.md for more information."

Repo: https://github.com/golang-jwt/jwt