### PR TITLE
Corrected .PHONY target name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONEY: all setup test cover
+.PHONY: all setup test cover
 
 all: setup cover
 


### PR DESCRIPTION
In order for the intended purpose to take effect, the target name must be .PHONY. See http://www.gnu.org/software/make/manual/make.html#Phony-Targets