### PR TITLE
Use jwtRegisteredClaims instead of jwt.StandardClaims

### DIFF
--- a/apple/secret.go
+++ b/apple/secret.go
@@ -31,12 +31,18 @@ func GenerateClientSecret(signingKey, teamID, clientID, keyID string) (string, e
 
 	// Create the Claims
 	now := time.Now()
-	claims := &jwt.StandardClaims{
-		Issuer:    teamID,
-		IssuedAt:  now.Unix(),
-		ExpiresAt: now.Add(time.Hour*24*180 - time.Second).Unix(), // 180 days
-		Audience:  "https://appleid.apple.com",
-		Subject:   clientID,
+	claims := &jwt.RegisteredClaims{
+		Issuer: teamID,
+		IssuedAt: &jwt.NumericDate{
+			Time: now,
+		},
+		ExpiresAt: &jwt.NumericDate{
+			Time: now.Add(time.Hour*24*180 - time.Second), // 180 days
+		},
+		Audience: jwt.ClaimStrings{
+			"https://appleid.apple.com",
+		},
+		Subject: clientID,
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)


### PR DESCRIPTION
jwt.StandardClaims has been marked as deprecated. (https://pkg.go.dev/github.com/golang-jwt/jwt/v4#StandardClaims)
Change to use jwt.StandardClaims as suggested.