### PR TITLE
Lower Go Version To 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Timothylock/go-signin-with-apple
 
-go 1.22
+go 1.18
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.2.1


### PR DESCRIPTION
The highest version required by dependencies is 1.18 so we can safely drop the required Go version of this module to 1.18 as well