### PR TITLE
fix: Update ClientOptions struct fields to export them

### DIFF
--- a/apple/validator.go
+++ b/apple/validator.go
@@ -43,9 +43,9 @@ type Client struct {
 
 // ClientOptions is a struct to hold the options for the client
 type ClientOptions struct {
-	validationURL string
-	revokeURL     string
-	client        *http.Client
+	ValidationURL string
+	RevokeURL     string
+	Client        *http.Client
 }
 
 // New creates a Client object with the default URLs and a default http client
@@ -58,29 +58,29 @@ func New() *Client {
 // Deprecated: This function is deprecated and will be removed in a future version. Use NewWithOptions instead.
 func NewWithURL(validationURL string, revokeURL string) *Client {
 	return NewWithOptions(ClientOptions{
-		validationURL: validationURL,
-		revokeURL:     revokeURL,
+		ValidationURL: validationURL,
+		RevokeURL:     revokeURL,
 	})
 }
 
 // NewWithOptions creates a Client object with custom options. It will default to the standard options if not provided
 func NewWithOptions(options ClientOptions) *Client {
-	if options.client == nil {
-		options.client = &http.Client{
+	if options.Client == nil {
+		options.Client = &http.Client{
 			Timeout: 5 * time.Second,
 		}
 	}
-	if options.validationURL == "" {
-		options.validationURL = ValidationURL
+	if options.ValidationURL == "" {
+		options.ValidationURL = ValidationURL
 	}
-	if options.revokeURL == "" {
-		options.revokeURL = RevokeURL
+	if options.RevokeURL == "" {
+		options.RevokeURL = RevokeURL
 	}
 
 	client := &Client{
-		validationURL: options.validationURL,
-		revokeURL:     options.revokeURL,
-		client:        options.client,
+		validationURL: options.ValidationURL,
+		revokeURL:     options.RevokeURL,
+		client:        options.Client,
 	}
 	return client
 }

--- a/apple/validator_test.go
+++ b/apple/validator_test.go
@@ -49,7 +49,7 @@ func TestNewWithOptions(t *testing.T) {
 		{
 			name: "custom validation url",
 			opts: ClientOptions{
-				validationURL: "customValidationURL",
+				ValidationURL: "customValidationURL",
 			},
 			expectedValidationURL: "customValidationURL",
 			expectedRevokeURL:     RevokeURL,
@@ -58,7 +58,7 @@ func TestNewWithOptions(t *testing.T) {
 		{
 			name: "custom revoke url",
 			opts: ClientOptions{
-				revokeURL: "customRevokeURL",
+				RevokeURL: "customRevokeURL",
 			},
 			expectedValidationURL: ValidationURL,
 			expectedRevokeURL:     "customRevokeURL",
@@ -67,7 +67,7 @@ func TestNewWithOptions(t *testing.T) {
 		{
 			name: "custom client timeout",
 			opts: ClientOptions{
-				client: &http.Client{
+				Client: &http.Client{
 					Timeout: 10 * time.Second,
 				},
 			},
@@ -78,9 +78,9 @@ func TestNewWithOptions(t *testing.T) {
 		{
 			name: "all custom options",
 			opts: ClientOptions{
-				validationURL: "customValidationURL",
-				revokeURL:     "customRevokeURL",
-				client: &http.Client{
+				ValidationURL: "customValidationURL",
+				RevokeURL:     "customRevokeURL",
+				Client: &http.Client{
 					Timeout: 10 * time.Second,
 				},
 			},


### PR DESCRIPTION
The changes involve updating the field names of `ClientOptions` struct to use exported (public) names in order to make them accessible outside the package.

Changes to `apple/validator.go`:

* Updated `ClientOptions` struct to use exported field names: `ValidationURL`, `RevokeURL`, and `Client`.
* Modified `NewWithURL` and `NewWithOptions` functions to use the updated field names in the `ClientOptions` struct.

Changes to `apple/validator_test.go`:

* Updated test cases in `TestNewWithOptions` to use the new exported field names in the `ClientOptions` struct. 


By the way, love this library, great work! :+1: