### PR TITLE
feat: use HTTClient interface instead of http.Client

### DIFF
--- a/apple/validator.go
+++ b/apple/validator.go
@@ -34,18 +34,24 @@ type ValidationClient interface {
 	RevokeRefreshToken(ctx context.Context, reqBody RevokeRefreshTokenRequest, result interface{}) error
 }
 
+// HTTPClient is an interface for an HTTP client to have a support
+// of an http.Client wrappers or replacements (e.g., some custom mocks).
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Client implements ValidationClient
 type Client struct {
 	validationURL string
 	revokeURL     string
-	client        *http.Client
+	client        HTTPClient
 }
 
 // ClientOptions is a struct to hold the options for the client
 type ClientOptions struct {
 	ValidationURL string
 	RevokeURL     string
-	Client        *http.Client
+	Client        HTTPClient
 }
 
 // New creates a Client object with the default URLs and a default http client
@@ -176,7 +182,7 @@ func GetClaims(idToken string) (*jwt.MapClaims, error) {
 	return &claims, nil
 }
 
-func doRequest(ctx context.Context, client *http.Client, result interface{}, url string, data url.Values) error {
+func doRequest(ctx context.Context, client HTTPClient, result interface{}, url string, data url.Values) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err

--- a/apple/validator_test.go
+++ b/apple/validator_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -98,7 +99,10 @@ func TestNewWithOptions(t *testing.T) {
 			assert.Equal(t, tt.expectedValidationURL, c.validationURL, "expected the client's validation url to be %s, but got %s", tt.expectedValidationURL, c.validationURL)
 			assert.Equal(t, tt.expectedRevokeURL, c.revokeURL, "expected the client's revoke url to be %s, but got %s", tt.expectedRevokeURL, c.revokeURL)
 			assert.NotNil(t, c.client, "the client's http client should not be empty")
-			assert.Equal(t, tt.expectedClientTimeout, c.client.Timeout, "expected the client's timeout to be %s, but got %s", tt.expectedClientTimeout, c.client.Timeout)
+
+			httpClient, ok := c.client.(*http.Client)
+			require.True(t, ok, "the client's http client should be of type *http.Client")
+			assert.Equal(t, tt.expectedClientTimeout, httpClient.Timeout, "expected the client's timeout to be %s, but got %s", tt.expectedClientTimeout, httpClient.Timeout)
 		})
 	}
 }


### PR DESCRIPTION
Added `HTTPClient` interface instead of direct usage of the `http.Client` to add a support of using some custom client realisations or wrappers.

For example, I have a drop-in replacement client with a retries, and I'll be able to use it with a `go-signin-with-apple` in case of this interface. Also, it may be useful for some custom mock realisations.