### PR TITLE
feat: Skip Decoding Body On Revoke Calls

### DIFF
--- a/apple/validator.go
+++ b/apple/validator.go
@@ -101,7 +101,7 @@ func (c *Client) VerifyWebToken(ctx context.Context, reqBody WebValidationTokenR
 		"grant_type":    {"authorization_code"},
 	}
 
-	return doRequest(ctx, c.client, &result, c.validationURL, data)
+	return doRequest(ctx, c.client, &result, c.validationURL, data, false)
 }
 
 // VerifyAppToken sends the AppValidationTokenRequest and gets validation result
@@ -113,7 +113,7 @@ func (c *Client) VerifyAppToken(ctx context.Context, reqBody AppValidationTokenR
 		"grant_type":    {"authorization_code"},
 	}
 
-	return doRequest(ctx, c.client, &result, c.validationURL, data)
+	return doRequest(ctx, c.client, &result, c.validationURL, data, false)
 }
 
 // VerifyRefreshToken sends the WebValidationTokenRequest and gets validation result
@@ -125,7 +125,7 @@ func (c *Client) VerifyRefreshToken(ctx context.Context, reqBody ValidationRefre
 		"grant_type":    {"refresh_token"},
 	}
 
-	return doRequest(ctx, c.client, &result, c.validationURL, data)
+	return doRequest(ctx, c.client, &result, c.validationURL, data, false)
 }
 
 // RevokeRefreshToken revokes the Refresh Token and gets the revoke result
@@ -137,7 +137,7 @@ func (c *Client) RevokeRefreshToken(ctx context.Context, reqBody RevokeRefreshTo
 		"token_type_hint": {"refresh_token"},
 	}
 
-	return doRequest(ctx, c.client, &result, c.revokeURL, data)
+	return doRequest(ctx, c.client, &result, c.revokeURL, data, true)
 }
 
 // RevokeAccessToken revokes the Access Token and gets the revoke result
@@ -149,7 +149,7 @@ func (c *Client) RevokeAccessToken(ctx context.Context, reqBody RevokeAccessToke
 		"token_type_hint": {"access_token"},
 	}
 
-	return doRequest(ctx, c.client, &result, c.revokeURL, data)
+	return doRequest(ctx, c.client, &result, c.revokeURL, data, true)
 }
 
 // GetUniqueID decodes the id_token response and returns the unique subject ID to identify the user
@@ -182,7 +182,7 @@ func GetClaims(idToken string) (*jwt.MapClaims, error) {
 	return &claims, nil
 }
 
-func doRequest(ctx context.Context, client HTTPClient, result interface{}, url string, data url.Values) error {
+func doRequest(ctx context.Context, client HTTPClient, result interface{}, url string, data url.Values, skipDecodingBody bool) error {
 	req, err := http.NewRequestWithContext(ctx, "POST", url, strings.NewReader(data.Encode()))
 	if err != nil {
 		return err
@@ -197,7 +197,12 @@ func doRequest(ctx context.Context, client HTTPClient, result interface{}, url s
 		return err
 	}
 
-	defer res.Body.Close()
+	if skipDecodingBody && (res.StatusCode < 200 || res.StatusCode >= 300) {
+		return fmt.Errorf("apple returned a bad status and response was not decoded: %s", res.Status)
+	} else if skipDecodingBody {
+		return nil
+	}
 
+	defer res.Body.Close()
 	return json.NewDecoder(res.Body).Decode(result)
 }

--- a/apple/validator.go
+++ b/apple/validator.go
@@ -218,6 +218,10 @@ func doRevokeRequest(ctx context.Context, client HTTPClient, result interface{},
 		return err
 	}
 
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
 	// We only need to decode the result if there was an error. A successful revoke is a 200 without a body
 	if res.StatusCode < 200 || res.StatusCode >= 300 {
 		return json.NewDecoder(res.Body).Decode(result)

--- a/apple/validator_test.go
+++ b/apple/validator_test.go
@@ -25,7 +25,10 @@ func TestNew(t *testing.T) {
 }
 
 func TestNewWithURL(t *testing.T) {
-	c := NewWithURL("validationURL", "revokeURL")
+	c := NewWithOptions(ClientOptions{
+		ValidationURL: "validationURL",
+		RevokeURL:     "revokeURL",
+	})
 
 	assert.IsType(t, &Client{}, c, "expected New to return a Client type")
 	assert.Equal(t, "validationURL", c.validationURL, "expected the client's validation url to be %s, but got %s", "validationURL", c.validationURL)
@@ -194,20 +197,29 @@ func TestDoRequestSuccess(t *testing.T) {
 
 	var actual ValidationResponse
 
-	c := NewWithURL(srv.URL, "revokeUrl")
+	c := NewWithOptions(ClientOptions{
+		ValidationURL: srv.URL,
+		RevokeURL:     "revokeUrl",
+	})
 	assert.NoError(t, doRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}, false))
 	assert.Equal(t, "123", actual.IDToken)
 }
 
 func TestDoRequestBadServer(t *testing.T) {
 	var actual ValidationResponse
-	c := NewWithURL("foo.test", "revokeUrl")
+	c := NewWithOptions(ClientOptions{
+		ValidationURL: "foo.test",
+		RevokeURL:     "revokeUrl",
+	})
 	assert.Error(t, doRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}, false))
 }
 
 func TestDoRequestNewRequestFail(t *testing.T) {
 	var actual ValidationResponse
-	c := NewWithURL("http://fo  o.test", "revokeUrl")
+	c := NewWithOptions(ClientOptions{
+		ValidationURL: "http://fo  o.test",
+		RevokeURL:     "revokeUrl",
+	})
 	assert.Error(t, doRequest(context.Background(), c.client, &actual, c.validationURL, nil, false))
 }
 
@@ -307,7 +319,10 @@ func TestVerifyAppToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewWithURL(srv.URL, "revokeUrl")
+			c := NewWithOptions(ClientOptions{
+				ValidationURL: srv.URL,
+				RevokeURL:     "revokeUrl",
+			})
 			var resp ValidationResponse
 			err := c.VerifyAppToken(context.Background(), tt.req, &resp)
 
@@ -434,7 +449,10 @@ func TestVerifyNonAppToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewWithURL(srv.URL, "revokeUrl")
+			c := NewWithOptions(ClientOptions{
+				ValidationURL: srv.URL,
+				RevokeURL:     "revokeUrl",
+			})
 			var resp ValidationResponse
 			err := c.VerifyWebToken(context.Background(), tt.req, &resp)
 
@@ -552,7 +570,10 @@ func TestVerifyRefreshToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewWithURL(srv.URL, "revokeUrl")
+			c := NewWithOptions(ClientOptions{
+				ValidationURL: srv.URL,
+				RevokeURL:     "revokeUrl",
+			})
 			var resp ValidationResponse
 			err := c.VerifyRefreshToken(context.Background(), tt.req, &resp)
 
@@ -652,7 +673,10 @@ func TestRevokeRefreshToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewWithURL("validationUrl", srv.URL)
+			c := NewWithOptions(ClientOptions{
+				ValidationURL: "validationUrl",
+				RevokeURL:     srv.URL,
+			})
 			var resp ValidationResponse
 			err := c.RevokeRefreshToken(context.Background(), tt.req, &resp)
 
@@ -738,7 +762,10 @@ func TestRevokeAccessToken(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			c := NewWithURL("validationUrl", srv.URL)
+			c := NewWithOptions(ClientOptions{
+				ValidationURL: "validationUrl",
+				RevokeURL:     srv.URL,
+			})
 			var resp ValidationResponse
 			err := c.RevokeAccessToken(context.Background(), tt.req, &resp)
 

--- a/apple/validator_test.go
+++ b/apple/validator_test.go
@@ -201,7 +201,7 @@ func TestDoRequestSuccess(t *testing.T) {
 		ValidationURL: srv.URL,
 		RevokeURL:     "revokeUrl",
 	})
-	assert.NoError(t, doRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}, false))
+	assert.NoError(t, doValidationRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}))
 	assert.Equal(t, "123", actual.IDToken)
 }
 
@@ -211,7 +211,7 @@ func TestDoRequestBadServer(t *testing.T) {
 		ValidationURL: "foo.test",
 		RevokeURL:     "revokeUrl",
 	})
-	assert.Error(t, doRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}, false))
+	assert.Error(t, doValidationRequest(context.Background(), c.client, &actual, c.validationURL, url.Values{}))
 }
 
 func TestDoRequestNewRequestFail(t *testing.T) {
@@ -220,7 +220,7 @@ func TestDoRequestNewRequestFail(t *testing.T) {
 		ValidationURL: "http://fo  o.test",
 		RevokeURL:     "revokeUrl",
 	})
-	assert.Error(t, doRequest(context.Background(), c.client, &actual, c.validationURL, nil, false))
+	assert.Error(t, doValidationRequest(context.Background(), c.client, &actual, c.validationURL, nil))
 }
 
 func TestVerifyAppToken(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
-	github.com/stretchr/testify v1.10.0
+	github.com/stretchr/testify v1.11.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/golang-jwt/jwt/v5 v5.3.0 h1:pv4AsKCKKZuqlgs5sUmn4x8UlGa0kEVt/puTpKx9v
 github.com/golang-jwt/jwt/v5 v5.3.0/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
Addresses #48 

Skip the decoding of the body on revoke calls since apple specifies that no body is returned on those calls 

https://developer.apple.com/documentation/signinwithapplerestapi/revoke-tokens