### PR TITLE
feat: add VerifyIDToken with JWKS signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Full working examples can be found in the [example/](example/) directory:
 | Validate a refresh token | [refresh_validation_example_test.go](example/refresh_validation_example_test.go) |
 | Revoke an access token | [revoke_access_token_example_test.go](example/revoke_access_token_example_test.go) |
 | Revoke a refresh token | [revoke_refresh_token_example_test.go](example/revoke_refresh_token_example_test.go) |
-| Get typed ID token claims | [get_typed_claims_example_test.go](example/get_typed_claims_example_test.go) |
+| Verify an ID token (with signature check) | [verify_id_token_example_test.go](example/verify_id_token_example_test.go) |
+| Get typed ID token claims (no signature check) | [get_typed_claims_example_test.go](example/get_typed_claims_example_test.go) |
 | Migrate users across developer teams | [user_migration_example_test.go](example/user_migration_example_test.go) |
 | Handle server-to-server notifications | [server_notification_example_test.go](example/server_notification_example_test.go) |
 
@@ -76,12 +77,26 @@ Check `resp.Error` before using the response — Apple returns errors in the bod
 
 ---
 
-### Reading ID Token Claims
+### Which ID token method should I use?
 
-The `id_token` in the validation response is a JWT containing the user's identity. Use `GetTypedClaims` to decode it into a struct with proper Go types:
+The right choice depends on **who gave you the token**:
+
+| Token source | Method | Why |
+|---|---|---|
+| Client device (iOS app, web browser) | `VerifyIDToken` | Token passed through the client — signature must be checked |
+| Apple's API response (`VerifyAppToken` / `VerifyWebToken`) | `GetTypedClaims` | Your server fetched it over TLS directly from Apple — no tampering possible |
+
+### Verifying an ID Token from a Client Device
+
+When an iOS app or browser completes Sign in with Apple, the Apple SDK hands the client an `id_token`. The client sends that token to your server. Because it traveled through the client it could have been swapped, so you must verify the RS256 signature before trusting it.
 
 ```go
-claims, err := apple.GetTypedClaims(resp.IDToken)
+client := apple.New()
+
+claims, err := client.VerifyIDToken(ctx, idToken, clientID)
+if err != nil {
+    // token is invalid, expired, or not from Apple
+}
 
 fmt.Println(claims.Subject)        // stable unique user ID
 fmt.Println(claims.Email)          // user's email (if requested)
@@ -90,9 +105,25 @@ fmt.Println(claims.IsPrivateEmail) // bool — true if Apple private relay addre
 fmt.Println(claims.RealUserStatus) // 0=unsupported, 1=unknown, 2=likelyReal (iOS 14+)
 ```
 
-`GetTypedClaims` correctly handles Apple's older token format where `email_verified` is returned as the string `"true"` instead of a JSON boolean.
+`VerifyIDToken` fetches Apple's public JWKS, verifies the RS256 signature, and validates that `iss`, `aud`, and `exp` are all correct. The JWKS is cached for 15 minutes by default and refreshed automatically on key rotation.
 
-> **Note:** `GetTypedClaims` and `GetClaims` decode the token without verifying its signature. For most server-side flows this is safe because you obtained the token directly from Apple's validation endpoint over TLS. If you need standalone signature verification, it is on the roadmap.
+Tune the cache TTL via `ClientOptions`:
+
+```go
+client := apple.NewWithOptions(apple.ClientOptions{
+    JWKSCacheTTL: 30 * time.Minute,
+})
+```
+
+### Reading ID Token Claims from Apple's API Response
+
+When your server calls `VerifyAppToken` or `VerifyWebToken`, Apple returns an `id_token` directly to you over TLS. Because your server made the request, the token never passed through any client and cannot have been tampered with. Signature verification is redundant — use `GetTypedClaims` to decode the claims directly:
+
+```go
+claims, err := apple.GetTypedClaims(resp.IDToken)
+```
+
+`GetTypedClaims` handles Apple's older token format where `email_verified` is returned as the string `"true"` instead of a JSON boolean.
 
 ---
 
@@ -172,7 +203,7 @@ http.HandleFunc("/apple/notifications", func(w http.ResponseWriter, r *http.Requ
 
 Register your webhook URL under **Certificates, Identifiers & Profiles → your App ID → Sign in with Apple** in the Apple Developer portal. See [TN3194](https://developer.apple.com/documentation/technotes/tn3194-handling-account-deletions-and-revoking-tokens-for-sign-in-with-apple) for full details.
 
-> **Note:** Signature verification for server notifications is on the roadmap. The JWT is currently parsed without verifying Apple's RS256 signature.
+`ParseServerNotification` verifies the RS256 signature using the same JWKS cache as `VerifyIDToken`.
 
 ---
 

--- a/apple/doc.go
+++ b/apple/doc.go
@@ -3,10 +3,11 @@
 // It covers the full lifecycle of Sign in with Apple on your server:
 //
 //   - Validating authorization codes from iOS apps and web flows
+//   - Verifying ID token signatures against Apple's JWKS with automatic caching
 //   - Refreshing and revoking access tokens
 //   - Parsing ID token claims into typed Go structs
 //   - Migrating user identifiers when an app transfers between developer teams
-//   - Parsing server-to-server event notifications (account deletion, consent revoked)
+//   - Parsing and verifying server-to-server event notifications (account deletion, consent revoked)
 //
 // # Getting Started
 //
@@ -24,12 +25,25 @@
 //	    Code:         authorizationCode,
 //	}, &resp)
 //
-//	claims, err := apple.GetTypedClaims(resp.IDToken)
-//	fmt.Println(claims.Subject) // stable unique user ID
+// # ID Token Verification
 //
-// # ID Token Claims
+// [Client.VerifyIDToken] fetches Apple's public JWKS, verifies the RS256 signature,
+// and validates iss/aud/exp in one call. This is the recommended way to verify an
+// id_token received directly from a client device:
 //
-// [GetTypedClaims] decodes the id_token JWT into an [IDTokenClaims] struct.
+//	claims, err := client.VerifyIDToken(ctx, idToken, clientID)
+//	fmt.Println(claims.Subject)        // stable unique user ID
+//	fmt.Println(claims.Email)
+//	fmt.Println(claims.RealUserStatus) // 2 = likelyReal (iOS 14+)
+//
+// The JWKS is cached in memory (default 15 minutes) and refreshed automatically
+// when a new key ID is encountered, handling Apple key rotations transparently.
+//
+// # ID Token Claims Without Signature Verification
+//
+// [GetTypedClaims] decodes the id_token JWT into an [IDTokenClaims] struct without
+// verifying the signature. This is safe when the token was obtained via a server-side
+// call to [Client.VerifyAppToken] or [Client.VerifyWebToken] over TLS.
 // It handles Apple's quirk of encoding email_verified as either a JSON boolean
 // or the string "true"/"false" depending on the token version.
 //
@@ -42,12 +56,12 @@
 // # Server Notifications
 //
 // Apple sends a signed JWT to a registered webhook URL when a user revokes access
-// or deletes their Apple ID. Use [Client.ParseServerNotification] to parse
-// the event. You must delete all user data within 30 days of an account-delete event.
-// See Apple's TN3194 for details.
+// or deletes their Apple ID. Use [Client.ParseServerNotification] to verify the
+// RS256 signature and parse the event. You must delete all user data within 30 days
+// of an account-delete event. See Apple's TN3194 for details.
 //
 // # Customisation
 //
-// Use [NewWithOptions] to supply a custom HTTP client, timeout, or override
-// individual endpoint URLs (useful for testing against a mock server).
+// Use [NewWithOptions] to supply a custom HTTP client, timeout, JWKS cache TTL,
+// or override individual endpoint URLs (useful for testing against a mock server).
 package apple

--- a/apple/server_notifications.go
+++ b/apple/server_notifications.go
@@ -44,6 +44,8 @@ func (c *Client) ParseServerNotification(ctx context.Context, jwtPayload string)
 		},
 			jwt.WithIssuer(AppleIssuer),
 			jwt.WithExpirationRequired(),
+			// aud is not validated here because ParseServerNotification has no clientID
+			// parameter — the caller registers a single webhook endpoint for all apps.
 		)
 		if err != nil {
 			return nil, err

--- a/apple/server_notifications.go
+++ b/apple/server_notifications.go
@@ -8,23 +8,51 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 )
 
-// ParseServerNotification parses the JWT sent by Apple's server-to-server notification
-// system and returns the typed event payload.
+// ParseServerNotification verifies and parses the JWT sent by Apple's server-to-server
+// notification system, returning the typed event payload.
 //
 // Apple sends these notifications when a user deletes their account or revokes Sign in with Apple
 // access. The webhook URL is configured in the Apple Developer portal.
 // See https://developer.apple.com/documentation/technotes/tn3194-handling-account-deletions-and-revoking-tokens-for-sign-in-with-apple
 //
-// Note: signature verification against Apple's public keys is not yet implemented.
-func (c *Client) ParseServerNotification(_ context.Context, jwtPayload string) (*ServerNotificationClaims, error) {
-	token, _, err := new(jwt.Parser).ParseUnverified(jwtPayload, jwt.MapClaims{})
-	if err != nil {
-		return nil, err
-	}
+// The JWT signature is verified against Apple's public JWKS using the same cached key set as
+// VerifyIDToken. When ClientOptions.SkipIDTokenVerification is true, signature verification
+// is skipped (for use in tests only).
+func (c *Client) ParseServerNotification(ctx context.Context, jwtPayload string) (*ServerNotificationClaims, error) {
+	var m jwt.MapClaims
 
-	m, ok := token.Claims.(jwt.MapClaims)
-	if !ok {
-		return nil, fmt.Errorf("invalid token claims")
+	if c.skipVerify {
+		token, _, err := new(jwt.Parser).ParseUnverified(jwtPayload, jwt.MapClaims{})
+		if err != nil {
+			return nil, err
+		}
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok {
+			return nil, fmt.Errorf("invalid token claims")
+		}
+		m = claims
+	} else {
+		token, err := jwt.ParseWithClaims(jwtPayload, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
+			if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+				return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+			}
+			kid, ok := token.Header["kid"].(string)
+			if !ok {
+				return nil, fmt.Errorf("missing kid in token header")
+			}
+			return c.getPublicKey(ctx, kid)
+		},
+			jwt.WithIssuer(AppleIssuer),
+			jwt.WithExpirationRequired(),
+		)
+		if err != nil {
+			return nil, err
+		}
+		claims, ok := token.Claims.(jwt.MapClaims)
+		if !ok || !token.Valid {
+			return nil, fmt.Errorf("invalid token")
+		}
+		m = claims
 	}
 
 	return serverNotificationClaimsFromMap(m)

--- a/apple/server_notifications_test.go
+++ b/apple/server_notifications_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"crypto/rsa"
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -33,8 +35,9 @@ func makeNotificationToken(t *testing.T, privKey *rsa.PrivateKey, kid string, ba
 }
 
 func TestParseServerNotification(t *testing.T) {
-	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	privKey, jwksHandler := generateTestKey(t)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(jwksHandler))
+	defer jwksSrv.Close()
 
 	validBaseClaims := jwt.MapClaims{
 		"iss": AppleIssuer,
@@ -49,10 +52,10 @@ func TestParseServerNotification(t *testing.T) {
 		"event_time": float64(time.Now().Unix()),
 	}
 
-	t.Run("valid notification is parsed correctly", func(t *testing.T) {
-		payload := makeNotificationToken(t, privKey, "test-kid", validBaseClaims, validEvents)
+	t.Run("valid notification passes verification and parses correctly", func(t *testing.T) {
+		payload := makeNotificationToken(t, privKey, testKID, validBaseClaims, validEvents)
 
-		c := New()
+		c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
 		claims, err := c.ParseServerNotification(context.Background(), payload)
 		require.NoError(t, err)
 
@@ -68,12 +71,36 @@ func TestParseServerNotification(t *testing.T) {
 			"sub":        "user000",
 			"event_time": float64(time.Now().Unix()),
 		}
-		payload := makeNotificationToken(t, privKey, "test-kid", validBaseClaims, deleteEvents)
+		payload := makeNotificationToken(t, privKey, testKID, validBaseClaims, deleteEvents)
 
-		c := New()
+		c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
 		claims, err := c.ParseServerNotification(context.Background(), payload)
 		require.NoError(t, err)
 		assert.Equal(t, "account-delete", claims.Events.Type)
+	})
+
+	t.Run("tampered payload is rejected", func(t *testing.T) {
+		otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		payload := makeNotificationToken(t, otherKey, testKID, validBaseClaims, validEvents)
+
+		c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
+		_, err = c.ParseServerNotification(context.Background(), payload)
+		assert.Error(t, err)
+	})
+
+	t.Run("expired notification is rejected", func(t *testing.T) {
+		expiredClaims := jwt.MapClaims{
+			"iss": AppleIssuer,
+			"aud": "com.example.app",
+			"iat": float64(time.Now().Add(-2 * time.Hour).Unix()),
+			"exp": float64(time.Now().Add(-1 * time.Hour).Unix()),
+		}
+		payload := makeNotificationToken(t, privKey, testKID, expiredClaims, validEvents)
+
+		c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
+		_, err := c.ParseServerNotification(context.Background(), payload)
+		assert.Error(t, err)
 	})
 
 	t.Run("notification without events claim returns error", func(t *testing.T) {
@@ -84,17 +111,31 @@ func TestParseServerNotification(t *testing.T) {
 			"exp": float64(time.Now().Add(time.Hour).Unix()),
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodRS256, noEventsClaims)
-		token.Header["kid"] = "test-kid"
+		token.Header["kid"] = testKID
 		payload, err := token.SignedString(privKey)
 		require.NoError(t, err)
 
-		c := New()
+		c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
 		_, err = c.ParseServerNotification(context.Background(), payload)
 		assert.Error(t, err)
 	})
 
+	t.Run("skip verification bypasses signature check", func(t *testing.T) {
+		otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
+		payload := makeNotificationToken(t, otherKey, testKID, validBaseClaims, validEvents)
+
+		c := NewWithOptions(ClientOptions{
+			SkipIDTokenVerification: true,
+			AppleKeysURL:            "http://should-not-be-called.invalid",
+		})
+		claims, err := c.ParseServerNotification(context.Background(), payload)
+		require.NoError(t, err)
+		assert.Equal(t, "consent-revoked", claims.Events.Type)
+	})
+
 	t.Run("malformed jwt returns error", func(t *testing.T) {
-		c := New()
+		c := NewWithOptions(ClientOptions{SkipIDTokenVerification: true})
 		_, err := c.ParseServerNotification(context.Background(), "not.a.jwt")
 		assert.Error(t, err)
 	})

--- a/apple/validator.go
+++ b/apple/validator.go
@@ -2,11 +2,13 @@ package apple
 
 import (
 	"context"
+	"crypto"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -49,15 +51,40 @@ type Client struct {
 	validationURL string
 	revokeURL     string
 	migrationURL  string
+	keysURL       string
+	skipVerify    bool
 	client        HTTPClient
+
+	jwksMu        sync.RWMutex
+	jwksCache     map[string]crypto.PublicKey
+	jwksFetchedAt time.Time
+	jwksCacheTTL  time.Duration
 }
 
 // ClientOptions is a struct to hold the options for the client
 type ClientOptions struct {
+	// ValidationURL overrides the token validation endpoint.
+	// Defaults to https://appleid.apple.com/auth/token.
 	ValidationURL string
-	RevokeURL     string
-	MigrationURL  string
-	Client        HTTPClient
+	// RevokeURL overrides the token revocation endpoint.
+	// Defaults to https://appleid.apple.com/auth/revoke.
+	RevokeURL string
+	// MigrationURL overrides the user migration endpoint used by GetUserMigrationInfo.
+	// Defaults to https://appleid.apple.com/auth/usermigrationinfo.
+	MigrationURL string
+	// AppleKeysURL overrides the JWKS endpoint used to fetch Apple's public keys.
+	// Defaults to https://appleid.apple.com/auth/keys.
+	AppleKeysURL string
+	// JWKSCacheTTL controls how long Apple's public keys are cached before being
+	// re-fetched. Defaults to 15 minutes. Apple rotates keys infrequently; values
+	// between 5 and 60 minutes are reasonable for production.
+	JWKSCacheTTL time.Duration
+	// SkipIDTokenVerification disables RS256 signature verification in VerifyIDToken
+	// and ParseServerNotification. For use in tests only.
+	SkipIDTokenVerification bool
+	// Client overrides the HTTP client used for all outbound requests.
+	// Defaults to an http.Client with a 5-second timeout.
+	Client HTTPClient
 }
 
 // New creates a Client object with the default URLs and a default http client
@@ -91,11 +118,21 @@ func NewWithOptions(options ClientOptions) *Client {
 	if options.MigrationURL == "" {
 		options.MigrationURL = MigrationURL
 	}
+	if options.AppleKeysURL == "" {
+		options.AppleKeysURL = AppleKeysURL
+	}
+	if options.JWKSCacheTTL == 0 {
+		options.JWKSCacheTTL = 15 * time.Minute
+	}
 
 	return &Client{
 		validationURL: options.ValidationURL,
 		revokeURL:     options.RevokeURL,
 		migrationURL:  options.MigrationURL,
+		keysURL:       options.AppleKeysURL,
+		skipVerify:    options.SkipIDTokenVerification,
+		jwksCacheTTL:  options.JWKSCacheTTL,
+		jwksCache:     make(map[string]crypto.PublicKey),
 		client:        options.Client,
 	}
 }

--- a/apple/verify_id_token.go
+++ b/apple/verify_id_token.go
@@ -112,6 +112,10 @@ func (c *Client) refreshJWKS(ctx context.Context) error {
 	}
 	defer res.Body.Close()
 
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("Apple JWKS endpoint returned HTTP %d", res.StatusCode)
+	}
+
 	var jwks jwksResponse
 	if err := json.NewDecoder(res.Body).Decode(&jwks); err != nil {
 		return fmt.Errorf("failed to decode Apple JWKS: %w", err)

--- a/apple/verify_id_token.go
+++ b/apple/verify_id_token.go
@@ -1,0 +1,152 @@
+package apple
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+const (
+	// AppleKeysURL is the endpoint that serves Apple's public JWKS for token signature verification.
+	AppleKeysURL = "https://appleid.apple.com/auth/keys"
+)
+
+type jwksResponse struct {
+	Keys []jwkKey `json:"keys"`
+}
+
+type jwkKey struct {
+	Kty string `json:"kty"`
+	Kid string `json:"kid"`
+	Use string `json:"use"`
+	Alg string `json:"alg"`
+	N   string `json:"n"`
+	E   string `json:"e"`
+}
+
+// VerifyIDToken fetches Apple's public JWKS (with caching), verifies the RS256 signature
+// on the id_token, validates the issuer, audience, and expiration, and returns typed claims.
+//
+// The JWKS is cached for JWKSCacheTTL (default 15 minutes). On a cache miss for a specific
+// key ID the cache is refreshed immediately to handle key rotation.
+//
+// When ClientOptions.SkipIDTokenVerification is true, signature verification is skipped and
+// claims are decoded without validation. For use in tests only.
+func (c *Client) VerifyIDToken(ctx context.Context, idToken, clientID string) (*IDTokenClaims, error) {
+	if c.skipVerify {
+		return GetTypedClaims(idToken)
+	}
+
+	token, err := jwt.ParseWithClaims(idToken, jwt.MapClaims{}, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodRSA); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		kid, ok := token.Header["kid"].(string)
+		if !ok {
+			return nil, fmt.Errorf("missing kid in token header")
+		}
+		return c.getPublicKey(ctx, kid)
+	},
+		jwt.WithIssuer(AppleIssuer),
+		jwt.WithAudience(clientID),
+		jwt.WithExpirationRequired(),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	m, ok := token.Claims.(jwt.MapClaims)
+	if !ok || !token.Valid {
+		return nil, fmt.Errorf("invalid token")
+	}
+
+	return idTokenClaimsFromMap(m), nil
+}
+
+// getPublicKey returns the RSA public key for the given kid.
+// It uses the in-memory JWKS cache, refreshing when the cache is stale or the kid is unknown.
+func (c *Client) getPublicKey(ctx context.Context, kid string) (crypto.PublicKey, error) {
+	c.jwksMu.RLock()
+	key, found := c.jwksCache[kid]
+	stale := time.Since(c.jwksFetchedAt) > c.jwksCacheTTL
+	c.jwksMu.RUnlock()
+
+	if found && !stale {
+		return key, nil
+	}
+
+	// Cache is stale or kid not found — refresh from Apple
+	if err := c.refreshJWKS(ctx); err != nil {
+		return nil, err
+	}
+
+	c.jwksMu.RLock()
+	key, found = c.jwksCache[kid]
+	c.jwksMu.RUnlock()
+
+	if !found {
+		return nil, fmt.Errorf("public key with kid %q not found in Apple JWKS", kid)
+	}
+	return key, nil
+}
+
+// refreshJWKS fetches the current key set from Apple and replaces the in-memory cache.
+func (c *Client) refreshJWKS(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, "GET", c.keysURL, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("user-agent", UserAgent)
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer res.Body.Close()
+
+	var jwks jwksResponse
+	if err := json.NewDecoder(res.Body).Decode(&jwks); err != nil {
+		return fmt.Errorf("failed to decode Apple JWKS: %w", err)
+	}
+
+	newCache := make(map[string]crypto.PublicKey, len(jwks.Keys))
+	for _, key := range jwks.Keys {
+		if key.Kty != "RSA" {
+			continue
+		}
+		pubKey, err := jwkToRSAPublicKey(key)
+		if err != nil {
+			return fmt.Errorf("invalid JWK with kid %q: %w", key.Kid, err)
+		}
+		newCache[key.Kid] = pubKey
+	}
+
+	c.jwksMu.Lock()
+	c.jwksCache = newCache
+	c.jwksFetchedAt = time.Now()
+	c.jwksMu.Unlock()
+
+	return nil
+}
+
+func jwkToRSAPublicKey(key jwkKey) (*rsa.PublicKey, error) {
+	nBytes, err := base64.RawURLEncoding.DecodeString(key.N)
+	if err != nil {
+		return nil, fmt.Errorf("invalid modulus: %w", err)
+	}
+	eBytes, err := base64.RawURLEncoding.DecodeString(key.E)
+	if err != nil {
+		return nil, fmt.Errorf("invalid exponent: %w", err)
+	}
+	n := new(big.Int).SetBytes(nBytes)
+	e := int(new(big.Int).SetBytes(eBytes).Int64())
+	return &rsa.PublicKey{N: n, E: e}, nil
+}

--- a/apple/verify_id_token_test.go
+++ b/apple/verify_id_token_test.go
@@ -9,6 +9,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -202,17 +203,17 @@ func TestVerifyIDTokenSkipVerification(t *testing.T) {
 func TestJWKSCacheIsTimed(t *testing.T) {
 	privKey, jwksHandler := generateTestKey(t)
 
-	callCount := 0
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		callCount.Add(1)
 		jwksHandler(w, r)
 	}))
 	defer srv.Close()
 
-	// Very short TTL so the second call sees a stale cache
+	// TTL of 100ms with a 200ms sleep gives ample headroom on loaded CI runners.
 	c := NewWithOptions(ClientOptions{
 		AppleKeysURL: srv.URL,
-		JWKSCacheTTL: 50 * time.Millisecond,
+		JWKSCacheTTL: 100 * time.Millisecond,
 	})
 
 	claims := jwt.MapClaims{
@@ -226,26 +227,26 @@ func TestJWKSCacheIsTimed(t *testing.T) {
 
 	_, err := c.VerifyIDToken(context.Background(), token, "com.example.app")
 	require.NoError(t, err)
-	assert.Equal(t, 1, callCount, "JWKS should be fetched once")
+	assert.Equal(t, int32(1), callCount.Load(), "JWKS should be fetched once")
 
 	// Second call within TTL — served from cache
 	_, err = c.VerifyIDToken(context.Background(), token, "com.example.app")
 	require.NoError(t, err)
-	assert.Equal(t, 1, callCount, "JWKS should be cached on second call")
+	assert.Equal(t, int32(1), callCount.Load(), "JWKS should be cached on second call")
 
 	// Wait for TTL to expire, then verify cache is refreshed
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 	_, err = c.VerifyIDToken(context.Background(), token, "com.example.app")
 	require.NoError(t, err)
-	assert.Equal(t, 2, callCount, "JWKS should be refreshed after TTL expires")
+	assert.Equal(t, int32(2), callCount.Load(), "JWKS should be refreshed after TTL expires")
 }
 
 func TestJWKSCacheRefreshesOnUnknownKID(t *testing.T) {
 	privKey, jwksHandler := generateTestKey(t)
 
-	callCount := 0
+	var callCount atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		callCount++
+		callCount.Add(1)
 		jwksHandler(w, r)
 	}))
 	defer srv.Close()
@@ -265,7 +266,7 @@ func TestJWKSCacheRefreshesOnUnknownKID(t *testing.T) {
 	// First call — fetches JWKS
 	_, err := c.VerifyIDToken(context.Background(), makeIDToken(t, privKey, validClaims), "com.example.app")
 	require.NoError(t, err)
-	assert.Equal(t, 1, callCount)
+	assert.Equal(t, int32(1), callCount.Load())
 
 	// Token with an unknown kid — should trigger a second JWKS fetch then fail
 	unknownKIDToken := func() string {
@@ -276,7 +277,7 @@ func TestJWKSCacheRefreshesOnUnknownKID(t *testing.T) {
 	}()
 	_, err = c.VerifyIDToken(context.Background(), unknownKIDToken, "com.example.app")
 	assert.Error(t, err)
-	assert.Equal(t, 2, callCount, "unknown kid should trigger a JWKS refresh")
+	assert.Equal(t, int32(2), callCount.Load(), "unknown kid should trigger a JWKS refresh")
 }
 
 func TestGetTypedClaims(t *testing.T) {

--- a/apple/verify_id_token_test.go
+++ b/apple/verify_id_token_test.go
@@ -1,0 +1,304 @@
+package apple
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testKID = "test-key-id"
+
+// generateTestKey creates an RSA key pair and a JWKS handler for use in tests.
+func generateTestKey(t *testing.T) (*rsa.PrivateKey, http.HandlerFunc) {
+	t.Helper()
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	nB64 := base64.RawURLEncoding.EncodeToString(privKey.PublicKey.N.Bytes())
+	eB64 := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(privKey.PublicKey.E)).Bytes())
+
+	jwksBody, err := json.Marshal(map[string]interface{}{
+		"keys": []map[string]interface{}{
+			{"kty": "RSA", "kid": testKID, "use": "sig", "alg": "RS256", "n": nB64, "e": eB64},
+		},
+	})
+	require.NoError(t, err)
+
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write(jwksBody)
+	}
+	return privKey, handler
+}
+
+// makeIDToken creates a signed Apple-style ID token for testing.
+func makeIDToken(t *testing.T, privKey *rsa.PrivateKey, claims jwt.MapClaims) string {
+	t.Helper()
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = testKID
+	signed, err := token.SignedString(privKey)
+	require.NoError(t, err)
+	return signed
+}
+
+func TestVerifyIDToken(t *testing.T) {
+	privKey, jwksHandler := generateTestKey(t)
+	jwksSrv := httptest.NewServer(http.HandlerFunc(jwksHandler))
+	defer jwksSrv.Close()
+
+	clientID := "com.example.app"
+
+	validClaims := jwt.MapClaims{
+		"iss":              AppleIssuer,
+		"aud":              clientID,
+		"sub":              "user123",
+		"email":            "user@example.com",
+		"email_verified":   true,
+		"is_private_email": false,
+		"real_user_status": float64(2),
+		"auth_time":        float64(time.Now().Unix()),
+		"iat":              float64(time.Now().Unix()),
+		"exp":              float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	tests := []struct {
+		name       string
+		buildToken func() string
+		clientID   string
+		wantErr    bool
+		check      func(t *testing.T, claims *IDTokenClaims)
+	}{
+		{
+			name:       "valid token returns correct typed claims",
+			buildToken: func() string { return makeIDToken(t, privKey, validClaims) },
+			clientID:   clientID,
+			wantErr:    false,
+			check: func(t *testing.T, c *IDTokenClaims) {
+				assert.Equal(t, "user123", c.Subject)
+				assert.Equal(t, "user@example.com", c.Email)
+				assert.True(t, c.EmailVerified)
+				assert.Equal(t, 2, c.RealUserStatus)
+				assert.Equal(t, AppleIssuer, c.Issuer)
+				assert.Equal(t, clientID, c.Audience)
+			},
+		},
+		{
+			name:       "wrong audience is rejected",
+			buildToken: func() string { return makeIDToken(t, privKey, validClaims) },
+			clientID:   "com.other.app",
+			wantErr:    true,
+		},
+		{
+			name: "expired token is rejected",
+			buildToken: func() string {
+				return makeIDToken(t, privKey, jwt.MapClaims{
+					"iss": AppleIssuer,
+					"aud": clientID,
+					"sub": "user123",
+					"iat": float64(time.Now().Add(-2 * time.Hour).Unix()),
+					"exp": float64(time.Now().Add(-1 * time.Hour).Unix()),
+				})
+			},
+			clientID: clientID,
+			wantErr:  true,
+		},
+		{
+			name: "wrong issuer is rejected",
+			buildToken: func() string {
+				return makeIDToken(t, privKey, jwt.MapClaims{
+					"iss": "https://evil.example.com",
+					"aud": clientID,
+					"sub": "user123",
+					"iat": float64(time.Now().Unix()),
+					"exp": float64(time.Now().Add(time.Hour).Unix()),
+				})
+			},
+			clientID: clientID,
+			wantErr:  true,
+		},
+		{
+			name: "token signed by unknown key is rejected",
+			buildToken: func() string {
+				otherKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+				token := jwt.NewWithClaims(jwt.SigningMethodRS256, validClaims)
+				token.Header["kid"] = testKID
+				signed, err := token.SignedString(otherKey)
+				require.NoError(t, err)
+				return signed
+			},
+			clientID: clientID,
+			wantErr:  true,
+		},
+		{
+			name: "token with unknown kid triggers cache refresh and fails",
+			buildToken: func() string {
+				token := jwt.NewWithClaims(jwt.SigningMethodRS256, validClaims)
+				token.Header["kid"] = "unknown-kid"
+				signed, err := token.SignedString(privKey)
+				require.NoError(t, err)
+				return signed
+			},
+			clientID: clientID,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := NewWithOptions(ClientOptions{AppleKeysURL: jwksSrv.URL})
+			claims, err := c.VerifyIDToken(context.Background(), tt.buildToken(), tt.clientID)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tt.check != nil {
+				tt.check(t, claims)
+			}
+		})
+	}
+}
+
+func TestVerifyIDTokenSkipVerification(t *testing.T) {
+	// Sign with a key that is NOT in any JWKS server
+	unregisteredKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	claims := jwt.MapClaims{
+		"iss":   AppleIssuer,
+		"aud":   "com.example.app",
+		"sub":   "user456",
+		"email": "test@example.com",
+		"iat":   float64(time.Now().Unix()),
+		"exp":   float64(time.Now().Add(time.Hour).Unix()),
+	}
+	token := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
+	token.Header["kid"] = testKID
+	signed, err := token.SignedString(unregisteredKey)
+	require.NoError(t, err)
+
+	c := NewWithOptions(ClientOptions{
+		SkipIDTokenVerification: true,
+		AppleKeysURL:            "http://should-not-be-called.invalid",
+	})
+	result, err := c.VerifyIDToken(context.Background(), signed, "com.example.app")
+	require.NoError(t, err)
+	assert.Equal(t, "user456", result.Subject)
+	assert.Equal(t, "test@example.com", result.Email)
+}
+
+func TestJWKSCacheIsTimed(t *testing.T) {
+	privKey, jwksHandler := generateTestKey(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		jwksHandler(w, r)
+	}))
+	defer srv.Close()
+
+	// Very short TTL so the second call sees a stale cache
+	c := NewWithOptions(ClientOptions{
+		AppleKeysURL: srv.URL,
+		JWKSCacheTTL: 50 * time.Millisecond,
+	})
+
+	claims := jwt.MapClaims{
+		"iss": AppleIssuer,
+		"aud": "com.example.app",
+		"sub": "u1",
+		"iat": float64(time.Now().Unix()),
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+	token := makeIDToken(t, privKey, claims)
+
+	_, err := c.VerifyIDToken(context.Background(), token, "com.example.app")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "JWKS should be fetched once")
+
+	// Second call within TTL — served from cache
+	_, err = c.VerifyIDToken(context.Background(), token, "com.example.app")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount, "JWKS should be cached on second call")
+
+	// Wait for TTL to expire, then verify cache is refreshed
+	time.Sleep(60 * time.Millisecond)
+	_, err = c.VerifyIDToken(context.Background(), token, "com.example.app")
+	require.NoError(t, err)
+	assert.Equal(t, 2, callCount, "JWKS should be refreshed after TTL expires")
+}
+
+func TestJWKSCacheRefreshesOnUnknownKID(t *testing.T) {
+	privKey, jwksHandler := generateTestKey(t)
+
+	callCount := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		jwksHandler(w, r)
+	}))
+	defer srv.Close()
+
+	// Long TTL — cache won't expire, but an unknown kid should still trigger a refresh
+	c := NewWithOptions(ClientOptions{
+		AppleKeysURL: srv.URL,
+		JWKSCacheTTL: time.Hour,
+	})
+
+	validClaims := jwt.MapClaims{
+		"iss": AppleIssuer, "aud": "com.example.app", "sub": "u1",
+		"iat": float64(time.Now().Unix()),
+		"exp": float64(time.Now().Add(time.Hour).Unix()),
+	}
+
+	// First call — fetches JWKS
+	_, err := c.VerifyIDToken(context.Background(), makeIDToken(t, privKey, validClaims), "com.example.app")
+	require.NoError(t, err)
+	assert.Equal(t, 1, callCount)
+
+	// Token with an unknown kid — should trigger a second JWKS fetch then fail
+	unknownKIDToken := func() string {
+		tok := jwt.NewWithClaims(jwt.SigningMethodRS256, validClaims)
+		tok.Header["kid"] = "unknown-kid"
+		s, _ := tok.SignedString(privKey)
+		return s
+	}()
+	_, err = c.VerifyIDToken(context.Background(), unknownKIDToken, "com.example.app")
+	assert.Error(t, err)
+	assert.Equal(t, 2, callCount, "unknown kid should trigger a JWKS refresh")
+}
+
+func TestGetTypedClaims(t *testing.T) {
+	// Token where email_verified and is_private_email are strings (older Apple format)
+	// Payload: {"iss":"https://appleid.apple.com","aud":"com.example.app","exp":1568395678,
+	// "iat":1568395078,"sub":"082649.93391d8e1192f56b8c1ch39gs2a47e2.9732",
+	// "email":"foo@bar.com","email_verified":"true","is_private_email":"true","auth_time":1568395076}
+	oldFormatToken := "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2FwcGxlaWQuYXBwbGUuY29tIiwiYXVkIjoiY29tLmV4YW1wbGUuYXBwIiwiZXhwIjoxNTY4Mzk1Njc4LCJpYXQiOjE1NjgzOTUwNzgsInN1YiI6IjA4MjY0OS45MzM5MWQ4ZTExOTJmNTZiOGMxY2gzOWdzMmE0N2UyLjk3MzIiLCJhdF9oYXNoIjoickU3b3Brb1BSeVBseV9Pc2Rhc2RFQ1ZnIiwiZW1haWwiOiJmb29AYmFyLmNvbSIsImVtYWlsX3ZlcmlmaWVkIjoidHJ1ZSIsImlzX3ByaXZhdGVfZW1haWwiOiJ0cnVlIiwiYXV0aF90aW1lIjoxNTY4Mzk1MDc2fQ.yPyUS_5k8RMvfowGylHqiCJqYwe-AOGtpBnjvqP4Na8"
+
+	claims, err := GetTypedClaims(oldFormatToken)
+	require.NoError(t, err)
+
+	assert.Equal(t, "foo@bar.com", claims.Email)
+	assert.Equal(t, "082649.93391d8e1192f56b8c1ch39gs2a47e2.9732", claims.Subject)
+	assert.Equal(t, AppleIssuer, claims.Issuer)
+	assert.Equal(t, "com.example.app", claims.Audience)
+	assert.True(t, claims.EmailVerified, "email_verified string 'true' should parse as true")
+	assert.True(t, claims.IsPrivateEmail, "is_private_email string 'true' should parse as true")
+	assert.Equal(t, int64(1568395076), claims.AuthTime)
+}
+
+func TestGetTypedClaimsInvalidToken(t *testing.T) {
+	_, err := GetTypedClaims("not.a.token")
+	assert.Error(t, err)
+}

--- a/example/verify_id_token_example_test.go
+++ b/example/verify_id_token_example_test.go
@@ -1,0 +1,47 @@
+package example
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/Timothylock/go-signin-with-apple/apple"
+)
+
+/*
+This example shows how to verify an ID token received directly from a client device
+(iOS, macOS, or web). VerifyIDToken fetches Apple's public JWKS, verifies the RS256
+signature, and validates iss/aud/exp in a single call.
+
+Use this when the client sends you an id_token and you need to trust it without first
+calling VerifyAppToken. The JWKS is cached for JWKSCacheTTL (default 15 minutes) and
+refreshed automatically when Apple rotates keys.
+*/
+
+func TestVerifyIDToken(t *testing.T) {
+	// ClientID is the "Services ID" value for web flows, or bundle ID for iOS.
+	clientID := "com.your.app"
+
+	// The id_token sent by the client after a successful Sign in with Apple.
+	idToken := "the_id_token_from_the_client"
+
+	// Create a client with the default JWKS cache TTL of 15 minutes.
+	// Use NewWithOptions to tune the TTL or supply a custom HTTP client.
+	client := apple.NewWithOptions(apple.ClientOptions{
+		JWKSCacheTTL: 30 * time.Minute,
+	})
+
+	claims, err := client.VerifyIDToken(context.Background(), idToken, clientID)
+	if err != nil {
+		// Token is invalid, expired, or the signature does not match Apple's keys.
+		fmt.Println("token verification failed: " + err.Error())
+		return
+	}
+
+	fmt.Println(claims.Subject)        // stable unique user ID — use this as your primary key
+	fmt.Println(claims.Email)          // present only if the user shared their email
+	fmt.Println(claims.EmailVerified)  // bool
+	fmt.Println(claims.IsPrivateEmail) // true if Apple private relay address
+	fmt.Println(claims.RealUserStatus) // 2 = likelyReal (iOS 14+)
+}


### PR DESCRIPTION
  Add Client.VerifyIDToken, which fetches Apple's public JWKS, verifies the
  RS256 signature, and validates iss/aud/exp in a single call. This fills the
  main gap vs competing libraries and makes the library safe for server flows
  where the id_token arrives directly from a client device.

  - JWKS is cached in memory with a configurable TTL (default 15 min) and refreshed automatically when an unknown key ID is encountered, handling Apple key rotations transparently
  - ParseServerNotification now also verifies the RS256 signature using the same JWKS cache
  - ClientOptions gains AppleKeysURL, JWKSCacheTTL, and SkipIDTokenVerification (test bypass); all fields have doc comments
  - README clarifies when to use VerifyIDToken vs GetTypedClaims based on who provided the token (client device vs Apple's API response)
  - New example and comprehensive tests covering TTL expiry, unknown-kid refresh, tampered payloads, and the skip-verification flag